### PR TITLE
Two logger issues

### DIFF
--- a/lib/connect-rest.js
+++ b/lib/connect-rest.js
@@ -40,7 +40,7 @@ var logger;
 
 function DummyLogger(){ }
 DummyLogger.prototype.info = function() { console.log( arguments ); };
-DummyLogger.prototype.debug = function() { console.debug( arguments ); };
+DummyLogger.prototype.debug = function() { console.log( arguments ); };
 DummyLogger.prototype.error = function() { console.error( arguments ); };
 
 


### PR DESCRIPTION
There are two logger issues:

1) The logger is not initialized to the DummyLogger if rester() is invoked with no arguments. Moving the initialization code outside of the IF block fixes the problem.

2) The DummyLogger calls console.debug(), which does not exist.

-Steve
