### PR TITLE
fix for error 500 on /discover path

### DIFF
--- a/lib/connect-rest.js
+++ b/lib/connect-rest.js
@@ -55,6 +55,7 @@ function addPath(key, path, action, prototypeObject, options){
 			} else {
 				var result = action(request, content);
 				var err;
+                options = options || {};
 				callback(err, { contentType: options.contentType || 'application/json', result : result, resOptions: { } } );
 			}
 		}, _


### PR DESCRIPTION
TypeError: Cannot read property 'contentType' of undefined
    at /var/www/epc/api/node_modules/connect-rest/lib/connect-rest.js:58:41
    at Route.maction (/var/www/epc/api/node_modules/connect-rest/lib/route.js:11:3)
    at /var/www/epc/api/node_modules/async/lib/async.js:594:23
    at /var/www/epc/api/node_modules/async/lib/async.js:548:21
    at /var/www/epc/api/node_modules/async/lib/async.js:224:13
    at iterate (/var/www/epc/api/node_modules/async/lib/async.js:131:13)
    at async.eachSeries (/var/www/epc/api/node_modules/async/lib/async.js:147:9)
    at _asyncMap (/var/www/epc/api/node_modules/async/lib/async.js:223:9)
    at Object.mapSeries (/var/www/epc/api/node_modules/async/lib/async.js:213:23)
    at Object.async.series (/var/www/epc/api/node_modules/async/lib/async.js:546:19)
