### PR TITLE
Using github flavored markdown for syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,9 @@ var rest = require('connect-rest');
 
 // sets up connect and adds other middlewares to parse query, parameters, content and session
 // use the ones you need
-var connectApp = connect();
-.use( bodyParser.urlencoded( { extended: true } ) )
-.use( bodyParser.json() )
-;
+var connectApp = connect()
+	.use( bodyParser.urlencoded( { extended: true } ) )
+	.use( bodyParser.json() );
 
 // initial configuration of connect-rest. all-of-them are optional.
 // default context is /api, all services are off by default


### PR DESCRIPTION
This change just converted all code examples to be use syntax highlighting with github flavored markdown which is also supported by NPM registry pages.
