### PR TITLE
publish paths based on export key, allow hyphens

### DIFF
--- a/lib/connect-rest.js
+++ b/lib/connect-rest.js
@@ -55,7 +55,7 @@ function purify( obj, config, level, path ) {
 
 var CONTEXT = '';
 
-var SERVICE_METHOD_PATTERN = /^[a-zA-Z]([a-zA-Z]|\d|_)*$/g;
+var SERVICE_METHOD_PATTERN = /^[a-zA-Z]([a-zA-Z]|\d|_|-)*$/g;
 
 var mapping = {
 	"HEAD": [],
@@ -320,12 +320,14 @@ exports.proxy = function proxyRest( method, path, remotePath, options ){
 };
 
 exports.publish = function (services){
+	var keys = _.keys(services);
 	_.each( _.values( services ), function(element, index, list){
-		if( _.isFunction( element ) && SERVICE_METHOD_PATTERN.test( element.name ) ){
+		var name = keys[index];
+		if( _.isFunction( element ) && SERVICE_METHOD_PATTERN.test( name ) ){
 			if( element.length === 1 )
-				exports.get( '/' + element.name, element );
+				exports.get( '/' + name, element );
 			if( element.length === 2 )
-				exports.post( '/' + element.name, element );
+				exports.post( '/' + name, element );
 		}
 	} );
 };

--- a/lib/connect-rest.js
+++ b/lib/connect-rest.js
@@ -55,7 +55,7 @@ function purify( obj, config, level, path ) {
 
 var CONTEXT = '';
 
-var SERVICE_METHOD_PATTERN = /^[a-zA-Z]([a-zA-Z]|\d|_|-)*$/g;
+var SERVICE_METHOD_PATTERN = /^[a-zA-Z]([a-zA-Z\d_-])*$/;
 
 var mapping = {
 	"HEAD": [],


### PR DESCRIPTION
Example services.js to go with

```
function record( request, content ){
    return 'saved';
}
exports['record-save'] = record;
```